### PR TITLE
Add Travis CI and unit tests for sledc wipe/write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ go:
 before_install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
+  - ./test/travis/build_kernel.sh
 script:
   - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
   - dep ensure
   - ./test/travis/build_kernel.sh
 script:
-  - go test
+  - go test -v ./test/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: go
+go:
+  - master
+before_install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure
+script:
+  - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ before_install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
   - ./test/travis/build_kernel.sh
+  - make clean
+  - make
 script:
   - go test -v ./test/...

--- a/sledc/main.go
+++ b/sledc/main.go
@@ -3,18 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"io/ioutil"
 	"math"
 	"net"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings" // remove newline from file
 
 	"github.com/ceftb/sled"
+	sledc "github.com/ceftb/sled/sledc/pkg"
 )
 
 var server = flag.String("server", "sled", "sled server to connect to")
@@ -50,190 +45,17 @@ func main() {
 	}
 
 	if resp.Wipe != nil {
-		wipe(resp.Wipe.Device)
+		sledc.WipeBlock(resp.Wipe.Device)
 	}
 	if resp.Write != nil {
-		write(resp.Write.Device, resp.Write.Image, resp.Write.Kernel, resp.Write.Initrd)
+		sledc.Write(resp.Write.Device, resp.Write.Image, resp.Write.Kernel, resp.Write.Initrd)
 	}
 	if resp.Kexec != nil {
-		kexec(resp.Kexec.Kernel, resp.Kexec.Append, resp.Kexec.Initrd)
+		sledc.Kexec(resp.Kexec.Kernel, resp.Kexec.Append, resp.Kexec.Initrd)
 	}
 	if resp.Wipe == nil && resp.Write == nil && resp.Kexec == nil {
 		log.Warn("received empty command from server")
 	}
-}
-
-// Wipe the specified device clean with zeros.
-func wipe(device string) {
-	log.Infof("wiping device %s", device)
-
-	if !blockDeviceExists(device) {
-		log.Fatalf("block device %s does not exist", device)
-	}
-
-	//wipe 1 kB at a time
-	buf := make([]byte, 1024)
-
-	size := getBlockDeviceSize(device)
-
-	dev, err := os.OpenFile(fmt.Sprintf("/dev/%s", device),
-		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
-		0666)
-	if err != nil {
-		log.Fatalf("write: error opening device %v", err)
-	}
-
-	// explicitly set N to 0
-	var N int64 = 0
-	// golang while loop, set each 1k block to 0
-	for N < size {
-		n, err := dev.Write(buf)
-		N += int64(n)
-		if n < 1024 {
-			break
-		}
-		if err != nil {
-			log.Fatalf("error zeroing disk: %v", err)
-		}
-	}
-	log.Printf("%d bytes zero'd in /dev/%s", size, device)
-
-	if N < size {
-		log.Warningf("only zeroed %d of %d bytes on disk", N, size)
-	} else {
-		log.Println("device wiped")
-	}
-}
-
-// Write the binary image to the specified device.
-func write(device string, image, kernel, initrd []byte) {
-	log.Infof("copying kernel to memory")
-
-	// write kernel to tmp, shouldnt be need to have more than one kernel
-	kdev, err := os.OpenFile(fmt.Sprintf("/tmp/kernel"),
-		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
-		0666)
-	if err != nil {
-		log.Fatalf("write: error opening device %v", err)
-	}
-	n, err := kdev.Write(kernel)
-	if err != nil {
-		log.Fatalf("write: error writing image - %v", err)
-	}
-	if n < len(kernel) {
-		log.Fatalf("write: failed to write kernel %d of %d bytes", n, len(kernel))
-	}
-	kdev.Close()
-
-	log.Infof("copying initrd to memory")
-
-	// write initramfs to tmp as well, again okay to overwrite
-	idev, err := os.OpenFile(fmt.Sprintf("/tmp/initrd"),
-		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
-		0666)
-	if err != nil {
-		log.Fatalf("write: error opening device %v", err)
-	}
-	n, err = idev.Write(initrd)
-	if err != nil {
-		log.Fatalf("write: error writing image - %v", err)
-	}
-	if n < len(initrd) {
-		log.Fatalf("write: failed to write kernel %d of %d bytes", n, len(initrd))
-	}
-	idev.Close()
-
-	log.Infof("writing image to device %s", device)
-
-	if !blockDeviceExists(device) {
-		log.Fatalf("block device %s does not exist", device)
-	}
-	// getBlockDeviceSize is in bytes
-	size := getBlockDeviceSize(device)
-	if int64(len(image)) > size {
-		log.Fatalf("image is larger than target device - %d > %d", len(image), size)
-	}
-
-	dev, err := os.OpenFile(fmt.Sprintf("/dev/%s", device),
-		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
-		0666)
-	if err != nil {
-		log.Fatalf("write: error opening device %v", err)
-	}
-	defer dev.Close()
-
-	n, err = dev.Write(image)
-	if err != nil {
-		log.Fatalf("write: error writing image - %v", err)
-	}
-	if n < len(image) {
-		log.Fatalf("write: failed to write full image %d of %d bytes", n, len(image))
-	} else {
-		log.Printf("wrote %d bytes to /dev/%s", n, device)
-	}
-}
-
-// kexec the image with the specified args
-func kexec(kernel, append, initrd string) {
-	log.Infof("kexec - %s %s %s", kernel, append, initrd)
-
-	// kexec -l -cmdline args -i initramfs kernel following u-root/golang-flag parsing
-	out, err := exec.Command("kexec", "-l", "-cmdline", append,
-		"-i", initrd, kernel).CombinedOutput()
-	if err != nil {
-		log.Fatalf("kexec load failed - %v : %s", err, out)
-	}
-
-	out, err = exec.Command("kexec", "-e").CombinedOutput()
-	if err != nil {
-		log.Fatalf("kexec execute failed - %v : %s", err, out)
-	}
-	log.Fatal("kexec did not exec ....")
-
-}
-
-// helpers ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-func blockDeviceExists(device string) bool {
-	devs := getBlockDevices()
-	for _, x := range devs {
-		if device == x {
-			return true
-		}
-	}
-	return false
-}
-
-func getBlockDevices() []string {
-
-	file, err := os.Open("/sys/block")
-	if err != nil {
-		log.Fatalf("error opening /sys/block - %v", err)
-	}
-	defer file.Close()
-
-	devs, err := file.Readdirnames(0)
-	if err != nil {
-		log.Fatalf("error reading /sys/block - %v", err)
-	}
-
-	return devs
-}
-
-func getBlockDeviceSize(device string) int64 {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/block/%s/size", device))
-	if err != nil {
-		log.Fatalf("error opening /sys/block/%s/size - %v", err)
-	}
-	// get rid of the nasty newline if it exists
-	contentStr := strings.TrimSuffix(string(content), "\n")
-	size, err := strconv.ParseInt(contentStr, 10, 0)
-	if err != nil {
-		log.Fatalf("error parsing /sys/block/%s/size = %v - %s", err, content)
-	}
-	// size is in disk sectors, multiply by 512 to get bytes
-	size = size * 512
-	return size
 }
 
 // 8 GB max image size$

--- a/sledc/pkg/sledc.go
+++ b/sledc/pkg/sledc.go
@@ -1,0 +1,185 @@
+package sledc
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings" // remove newline from file
+)
+
+// Wipe the specified device clean with zeros.
+// NOTE: now forcing "/dev" to be included in device name
+func WipeBlock(device string) {
+	log.Infof("wiping device %s", device)
+
+	if !blockDeviceExists(device) {
+		log.Fatalf("block device %s does not exist", device)
+	}
+
+	size := GetBlockDeviceSize(device)
+	// TODO: add return code
+	Wipe(device, size)
+
+}
+
+func Wipe(device string, size int64) {
+	//wipe 1 kB at a time
+	buf := make([]byte, 1024)
+
+	dev, err := os.OpenFile(device,
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+		0666)
+	if err != nil {
+		log.Fatalf("write: error opening device %v", err)
+	}
+
+	// explicitly set N to 0
+	var N int64 = 0
+	// golang while loop, set each 1k block to 0
+	for N < size {
+		n, err := dev.Write(buf)
+		N += int64(n)
+		if n < 1024 {
+			break
+		}
+		if err != nil {
+			log.Fatalf("error zeroing disk: %v", err)
+		}
+	}
+	log.Infof("%d bytes zero'd in %s", size, device)
+
+	if N < size {
+		log.Warningf("only zeroed %d of %d bytes on disk", N, size)
+	} else {
+		log.Infof("device wiped")
+	}
+}
+
+// Write the binary image to the specified device.
+func Write(device string, image, kernel, initrd []byte) {
+	// write the image to the block device
+	WriteBlockImage(device, image)
+	// write kernel, use flag "kernel" to name location
+	WriteOther(kernel, "kernel")
+	// write initramfs, use name "initrd"
+	WriteOther(initrd, "initrd")
+}
+
+// kexec the image with the specified args
+func Kexec(kernel, append, initrd string) {
+	log.Infof("kexec - %s %s %s", kernel, append, initrd)
+
+	// kexec -l -cmdline args -i initramfs kernel following u-root/golang-flag parsing
+	out, err := exec.Command("kexec", "-l", "-cmdline", append,
+		"-i", initrd, kernel).CombinedOutput()
+	if err != nil {
+		log.Fatalf("kexec load failed - %v : %s", err, out)
+	}
+
+	out, err = exec.Command("kexec", "-e").CombinedOutput()
+	if err != nil {
+		log.Fatalf("kexec execute failed - %v : %s", err, out)
+	}
+	log.Fatal("kexec did not exec ....")
+
+}
+
+// helpers ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+func blockDeviceExists(device string) bool {
+	devs := GetBlockDevices()
+	for _, x := range devs {
+		if device == x {
+			return true
+		}
+	}
+	return false
+}
+
+func GetBlockDevices() []string {
+
+	file, err := os.Open("/sys/block")
+	if err != nil {
+		log.Fatalf("error opening /sys/block - %v", err)
+	}
+	defer file.Close()
+
+	devs, err := file.Readdirnames(0)
+	if err != nil {
+		log.Fatalf("error reading /sys/block - %v", err)
+	}
+
+	return devs
+}
+
+func GetBlockDeviceSize(device string) int64 {
+	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/block/%s/size", device))
+	if err != nil {
+		log.Fatalf("error opening /sys/block/%s/size - %v", err)
+	}
+	// get rid of the nasty newline if it exists
+	contentStr := strings.TrimSuffix(string(content), "\n")
+	size, err := strconv.ParseInt(contentStr, 10, 0)
+	if err != nil {
+		log.Fatalf("error parsing /sys/block/%s/size = %v - %s", err, content)
+	}
+	// size is in disk sectors, multiply by 512 to get bytes
+	size = size * 512
+	return size
+}
+
+// writers ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+func WriteBlockImage(device string, image []byte) {
+	if !blockDeviceExists(device) {
+		log.Fatalf("block device %s does not exist", device)
+	}
+	// GetBlockDeviceSize is in bytes
+	size := GetBlockDeviceSize(device)
+	if int64(len(image)) > size {
+		log.Fatalf("image is larger than target device - %d > %d", len(image), size)
+	}
+
+	WriteImage(device, image)
+}
+
+func WriteImage(device string, image []byte) {
+	dev, err := os.OpenFile(device, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		log.Fatalf("write: error opening device %v", err)
+	}
+	defer dev.Close()
+
+	n, err := dev.Write(image)
+	if err != nil {
+		log.Fatalf("write: error writing image - %v", err)
+	}
+	if n < len(image) {
+		log.Fatalf("write: failed to write full image %d of %d bytes", n, len(image))
+	} else {
+		log.Infof("wrote %d bytes to %s", n, device)
+	}
+	log.Infof("writing image to device %s", device)
+}
+
+func WriteOther(kori []byte, flag string) {
+	log.Infof("copying %s to /tmp/%s", flag, flag)
+	// write kernel to tmp, shouldnt be need to have more than one kernel
+	dev, err := os.OpenFile(fmt.Sprintf("/tmp/%s", flag),
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+		0666)
+	if err != nil {
+		log.Fatalf("write: error opening device %v", err)
+	}
+	n, err := dev.Write(kori)
+	if err != nil {
+		log.Fatalf("write: error writing image - %v", err)
+	}
+	if n < len(kori) {
+		log.Fatalf("write: failed to write %s %d of %d bytes", flag, n, len(kori))
+	}
+	dev.Close()
+}

--- a/test/travis/build_kernel.sh
+++ b/test/travis/build_kernel.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# make sure we have pre-reqs to build kernel
+sudo apt-get install -y libncurses5-dev gcc make git exuberant-ctags bc libssl-dev libelf-dev
+
+LINUX_VERSION=4.14.32
+
+# wget kernel, b/c it is quick
+wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-$LINUX_VERSION.tar.xz
+
+tar xf linux-$LINUX_VERSION.tar.xz
+
+# root directory
+SLED=$(pwd | grep -Po '.*/sled')
+# current directory
+CWD=$(pwd)
+
+# copy our config to linux stable
+cp $SLED/kconfig/.config linux-$LINUX_VERSION/
+
+cd linux-$LINUX_VERSION
+
+# answer yes to all the new jazz
+yes "" | make oldconfig
+
+# build the kernel with our config
+make -j `nproc` modules bzImage
+
+# create the modules to build the initramfs, /tmp/mods default for scipts
+INSTALL_MOD_PATH=/tmp/mods make modules_install
+
+cd $CWD

--- a/test/unit/sledc_test.go
+++ b/test/unit/sledc_test.go
@@ -1,0 +1,108 @@
+package unit
+
+import (
+	"crypto/rand"
+	sledc "github.com/ceftb/sled/sledc/pkg"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"testing"
+)
+
+var DEVICE string = "test-device"
+var SIZE int = 1024 * 1024
+
+func TestSledcWipe(t *testing.T) {
+	log.Infof("Testing: Sledc Wipe")
+
+	// must be a /dev/test that we are wiping
+	createTestDevice(DEVICE, SIZE)
+
+	fistat, err := os.Stat(DEVICE)
+	if err != nil {
+		t.Errorf("device %s does not exist", DEVICE)
+	}
+	// get the size
+	size := fistat.Size()
+
+	// now we will test that wipe worked by reading all the bytes
+	sledc.Wipe(DEVICE, size)
+
+	buf := make([]byte, SIZE)
+	// validate that what we wrote and what we read are correct
+	readTestDevice(DEVICE, buf)
+}
+
+func TestSledcWrite(t *testing.T) {
+	log.Infof("Testing: Sledc Write")
+	// this should overwrite what we had there before - blank slate
+	createTestDevice(DEVICE, SIZE)
+	fistat, err := os.Stat(DEVICE)
+	if err != nil {
+		t.Errorf("device %s does not exist", DEVICE)
+	} else {
+	}
+	// get the size
+	size := fistat.Size()
+
+	randBytes := readRand(size)
+	log.Infof("Sledc Write: Writing Garbage to device")
+	writeGarbage(DEVICE, randBytes)
+	readTestDevice(DEVICE, randBytes)
+	log.Infof("Sledc Write: contents of device and buffer are equal")
+
+}
+
+// helpers ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+func readRand(numBytes int64) []byte {
+	randBytes := make([]byte, numBytes)
+	_, err := rand.Read(randBytes)
+	if err != nil {
+		log.Fatalf("could not read from rand %v", err)
+	}
+	return randBytes
+}
+
+func writeGarbage(device string, buf []byte) {
+	dev, err := os.OpenFile(device, os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatalf("write: error opening device %v", err)
+	}
+	_, err = dev.Write(buf)
+	if err != nil {
+		log.Fatalf("write: error writing to device %v", err)
+	}
+}
+
+// create a fake "device" - flat file
+func createTestDevice(device string, size int) {
+	dev, err := os.OpenFile(device, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		log.Fatalf("Error creating test device %v", err)
+	}
+	buf := make([]byte, size)
+	dev.Write(buf)
+}
+
+func readTestDevice(device string, testBuf []byte) {
+	size := len(testBuf)
+	buf := make([]byte, size)
+
+	dev, err := os.OpenFile(device, os.O_RDONLY, 0666)
+	if err != nil {
+		log.Fatalf("Read: error opening device %v", err)
+	}
+
+	_, err = dev.Read(buf)
+	if err != nil {
+		log.Fatalf("Read: error reading device %v", err)
+	}
+
+	if len(buf) != len(testBuf) {
+		log.Fatalf("device buffer does not equal write buffer size")
+	}
+	for i := range buf {
+		if buf[i] != testBuf[i] {
+			log.Fatalf("device buffer is not equal to write buffer")
+		}
+	}
+}


### PR DESCRIPTION
This branch adds travis CI but also breaks sledc into unit-testable segments.  The tests check wipe and write work of a file which should share the same file interface as a block device.  In this way no other configuration is necessary by travis CI.  For system testing using raven, block interface will be tested.